### PR TITLE
(fix-bug)修复拉取信息接口报错等BUG

### DIFF
--- a/kugga-services/src/main/java/com/ayang818/kugga/services/global/GlobalExceptionHandler.java
+++ b/kugga-services/src/main/java/com/ayang818/kugga/services/global/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.ayang818.kugga.services.global;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -13,6 +15,9 @@ import javax.servlet.http.HttpServletRequest;
  **/
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final  Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ResponseBody
     @ExceptionHandler(value = CustomizeException.class)
     public String serviceException(HttpServletRequest req, CustomizeException e) throws Exception {
@@ -22,6 +27,7 @@ public class GlobalExceptionHandler {
     @ResponseBody
     @ExceptionHandler(value = Exception.class)
     public String unExceptException(HttpServletRequest req, Exception e) throws Exception {
+        logger.error(e.getMessage());
         return "{\"message\": '服务端错误', status: '500'}";
     }
 }

--- a/kugga-services/src/main/java/com/ayang818/kugga/services/mapper/MsgExtMapper.java
+++ b/kugga-services/src/main/java/com/ayang818/kugga/services/mapper/MsgExtMapper.java
@@ -1,6 +1,7 @@
 package com.ayang818.kugga.services.mapper;
 
 import com.ayang818.kugga.services.pojo.vo.MsgTmp;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
@@ -26,5 +27,5 @@ public interface MsgExtMapper {
             @Result(property="sender",column="is_sender"),
             @Result(property="createTime",column="create_time")
     })
-    List<MsgTmp> fetchMsg(Long ownerUid, Long otherUid);
+    List<MsgTmp> fetchMsg(@Param("ownerUid") Long ownerUid,@Param("otherUid") Long otherUid);
 }

--- a/kugga-starter/src/main/java/com/ayang818/kugga/starter/controller/MsgController.java
+++ b/kugga-starter/src/main/java/com/ayang818/kugga/starter/controller/MsgController.java
@@ -29,6 +29,7 @@ public class MsgController {
     @ApiOperation("用户拉取消息接口")
     @RequestMapping(value = "/auth_api/msg", method = RequestMethod.GET)
     public ResultDto pullMsg(HttpServletRequest req, @RequestParam("otherUid") Long otherUid) {
+
         Long ownerUid = (Long) req.getAttribute("uid");
         MsgListVo msgListVo = msgService.fetchMsg(ownerUid, otherUid);
         return VoUtil.judge(msgListVo);

--- a/kugga-starter/src/main/java/com/ayang818/kugga/starter/controller/MsgController.java
+++ b/kugga-starter/src/main/java/com/ayang818/kugga/starter/controller/MsgController.java
@@ -28,10 +28,10 @@ public class MsgController {
 
     @ApiOperation("用户拉取消息接口")
     @RequestMapping(value = "/auth_api/msg", method = RequestMethod.GET)
-    public ResultDto pullMsg(HttpServletRequest req, @RequestParam("otherUid") Long otherUid) {
+    public ResultDto pullMsg(HttpServletRequest req, @RequestParam("otherUid") String otherUid) {
 
         Long ownerUid = (Long) req.getAttribute("uid");
-        MsgListVo msgListVo = msgService.fetchMsg(ownerUid, otherUid);
+        MsgListVo msgListVo = msgService.fetchMsg(ownerUid, Long.parseLong(otherUid));
         return VoUtil.judge(msgListVo);
     }
 }

--- a/kugga-starter/src/main/resources/application.properties
+++ b/kugga-starter/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 project.version=@project.apiVersion@
 server.port=5555
+server.tomcat.max-http-form-post-size=8192
+server.max-http-header-size=10240000
+server.tomcat.max-http-header-size=10240000
 
 # ==============MySQL ˝æ›ø‚≈‰÷√==============
 spring.datasource.host=${DATABASE_HOST}


### PR DESCRIPTION
1. 修复https请求直接打到tomcat容器导致的报错。解决方案：nginx做了一层代理。
2. 修复mybatis接口传参时，多个参数引起的参数丢失。解决方案：@Param注明参数名。